### PR TITLE
fixed average rating precision in stars

### DIFF
--- a/packages/react-frontend/src/routes/AlbumInfo.css
+++ b/packages/react-frontend/src/routes/AlbumInfo.css
@@ -39,10 +39,10 @@ img {
 }
 
 /* songs list formatting */
-/* .track-list {
+.track-list {
     grid-column: 1; 
     grid-row: 2; 
-} */
+}
 .song-list ul {
   list-style-type: none;
   padding: 0;
@@ -78,11 +78,19 @@ a {
 
 .reviews {
   margin-top: 20px;
-  width: 100%;
-  max-width: 700px;
+  width: 90%;
+  max-width: 700px; /* set a maximum width for larger screens */
+  box-sizing: border-box;
 }
 
-.reviews h3 {
+.reviews h3{
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial,
+  sans-serif;
+  margin-bottom: 10px;
+  margin: 5px 0;
+}
+
+.reviews p {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial,
     sans-serif;
   margin-bottom: 10px;
@@ -96,7 +104,8 @@ a {
   padding: 20px;
   margin-bottom: 10px;
   border-radius: 5px;
-  width: 100%; /* Ensure the review takes the full width of the parent */
+  width: 90%; 
+  max-width: 700px; /* set a maximum width for larger screens */
   box-sizing: border-box;
 }
 

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -120,7 +120,7 @@ export default function AlbumInfo() {
                   <span className="rating-stars">
                     <Rating value={parseFloat(review.rating)} precision={0.1} readOnly/>
                   </span>
-                  <p classname = "review">{review.content}</p>
+                  <p className = "review">{review.content}</p>
                 </div>
               ))
             )}

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -117,7 +117,6 @@ export default function AlbumInfo() {
             ) : (
               reviews.map((review) => (
                 <div key={review._id} className="review">
-                  <p className = "review">{review.content}</p>
                 </div>
               ))
             )}

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -117,7 +117,6 @@ export default function AlbumInfo() {
             ) : (
               reviews.map((review) => (
                 <div key={review._id} className="review">
-                  <span className="rating-stars">
                     <Rating value={parseFloat(review.rating)} precision={0.1} readOnly/>
                   </span>
                   <p className = "review">{review.content}</p>

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -97,9 +97,9 @@ export default function AlbumInfo() {
             <h2 className="album-title">{album.album_name}</h2>
             <p>
               {album.release_date.split("-")[0] + " "}
-              {artist.artist_name} |{"  "}
+              {artist.artist_name} |{"   "}
               <span className="rating-stars">
-                <Rating name="album-rating" value={parseFloat(avgRating)} precision={0.5}/>
+                <Rating name="album-rating" value={parseFloat(avgRating)} precision={0.1} readOnly/>
                 {avgRating !== "No reviews" && avgRating}
               </span>
             </p>
@@ -118,11 +118,9 @@ export default function AlbumInfo() {
               reviews.map((review) => (
                 <div key={review._id} className="review">
                   <span className="rating-stars">
-                    {Array.from({ length: 5 }, (_, i) =>
-                      i < review.rating ? "★" : "☆"
-                    ).join("")}
+                    <Rating value={parseFloat(review.rating)} precision={0.1} readOnly/>
                   </span>
-                  <p>{review.content}</p>
+                  <p classname = "review">{review.content}</p>
                 </div>
               ))
             )}
@@ -132,14 +130,10 @@ export default function AlbumInfo() {
             <p>{album.popularity}</p>
           </div>
           <div className="spotify-link">
-            <h3>Spotify Link</h3>
-            <a
-              href={album.spotify_link}
+            <a href={album.spotify_link}
               target="_blank"
-              rel="noopener noreferrer"
-            >
-              {album.spotify_link}
-            </a>
+              rel="noopener noreferrer">
+                Listen here on Spotify!</a>
           </div>
         </div>
       </div>

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Navbar from "./Navbar";
-import Rating from "@mui/material/Rating";
 import "./AlbumInfo.css";
 import { Link } from "react-router-dom";
 import Rating from "@mui/material/Rating";

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import Navbar from "./Navbar";
+import Rating from "@mui/material/Rating";
 import "./AlbumInfo.css";
 import { Link } from "react-router-dom";
 
@@ -57,32 +58,9 @@ export default function AlbumInfo() {
       });
   }
 
-  // function calculateAverage(reviews) {
-  //   if (reviews.length === 0) return 0;
-  //   // .reduce , iterates through array of reviews and sums up all ratings
-  //   const totalRating = reviews.reduce(
-  //     (sum, review) => sum + review.rating,
-  //     0
-  //   );
-  //   return totalRating / reviews.length;
-  // }
-
-  function getStarRating(rating) {
-    const fullStars = Math.floor(rating);
-    const halfStar = rating % 1 >= 0.5 ? 1 : 0;
-    const emptyStars = 5 - (fullStars + halfStar);
-    // half star is just going to be empty for now
-    return (
-      "★".repeat(fullStars) +
-      (halfStar ? "★" : "") +
-      "☆".repeat(emptyStars)
-    );
-  }
-
   if (error) return <div>Error: {error}</div>;
   if (!album || !artist) return <div>Loading...</div>;
 
-  // Calculate the average rating
   const avgRating =
     reviews.length > 0
       ? (
@@ -92,11 +70,6 @@ export default function AlbumInfo() {
           ) / reviews.length
         ).toFixed(1)
       : "No reviews";
-
-  const starRating =
-    avgRating !== "No reviews"
-      ? getStarRating(parseFloat(avgRating))
-      : "☆☆☆☆☆";
 
   return (
     <div className="album-info">
@@ -126,7 +99,7 @@ export default function AlbumInfo() {
               {album.release_date.split("-")[0] + " "}
               {artist.artist_name} |{"  "}
               <span className="rating-stars">
-                {starRating}{" "}
+                <Rating name="album-rating" value={parseFloat(avgRating)} precision={0.5}/>
                 {avgRating !== "No reviews" && avgRating}
               </span>
             </p>

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -117,7 +117,6 @@ export default function AlbumInfo() {
             ) : (
               reviews.map((review) => (
                 <div key={review._id} className="review">
-                    <Rating value={parseFloat(review.rating)} precision={0.1} readOnly/>
                   </span>
                   <p className = "review">{review.content}</p>
                 </div>

--- a/packages/react-frontend/src/routes/AlbumInfo.jsx
+++ b/packages/react-frontend/src/routes/AlbumInfo.jsx
@@ -117,7 +117,6 @@ export default function AlbumInfo() {
             ) : (
               reviews.map((review) => (
                 <div key={review._id} className="review">
-                  </span>
                   <p className = "review">{review.content}</p>
                 </div>
               ))


### PR DESCRIPTION

![image](https://github.com/shaaronl/jukeboxd/assets/72675377/592637dc-7a5d-41f8-92bd-f1a6047bc424)


<img width="1440" alt="Screen Shot 2024-05-28 at 10 20 43 PM" src="https://github.com/shaaronl/jukeboxd/assets/72675377/20ff67b4-2274-4619-bf0e-622a3d8f7d53">

The avg stars should now reflect the avg rating more precisely. Currently when there are  no reviews, it will just show a row of black star frames, as seen in image above, but I can change that to something else. Any suggestions?